### PR TITLE
Add `numpy` as requirement

### DIFF
--- a/requirements
+++ b/requirements
@@ -1,2 +1,3 @@
 PySide2
 urllib3
+numpy


### PR DESCRIPTION
Python does not ship with the `numpy` module by default, at least on Fedora.